### PR TITLE
Use workflow GitHub token as default `GITHUB_TOKEN`

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ jobs:
     steps:
       - uses: wow-actions/welcome@v1
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FIRST_ISSUE: |
             👋 @{{ author }}
              Thanks for opening your first issue here! Be sure to follow the issue template!
@@ -54,7 +53,7 @@ Various inputs are defined to let you configure the action:
 
 | Name | Description | Default |
 | --- | --- | --- |
-| `GITHUB_TOKEN` | The GitHub token for authentication. | N/A |
+| `GITHUB_TOKEN` | The GitHub token for authentication. | `${{ github.token }}` |
 | `FIRST_ISSUE` <br> or <br> `FIRST_ISSUE_COMMENT` | Comment to be posted to on first time issues. |  |
 | `FIRST_ISSUE_REACTIONS` | Reactions to be add to comment on first time issues. |  |
 | `FIRST_PR` <br> or <br> `FIRST_PR_COMMENT` | Comment to be posted to on PRs from first time contributors in your repository. |  |
@@ -91,7 +90,6 @@ jobs:
     steps:
       - uses: wow-actions/welcome@v1
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FIRST_ISSUE_REACTIONS: '+1, hooray, rocket, heart'
           FIRST_ISSUE_COMMENT: |
             👋 @{{ author }}
@@ -111,7 +109,6 @@ jobs:
     steps:
       - uses: wow-actions/welcome@v1
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FIRST_PR_REACTIONS: '+1, hooray, rocket, heart'
           FIRST_PR_COMMENT: |
             👋 @{{ author }}

--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,8 @@ author: bubkoo <bubkoo.wy@gmail.com>
 inputs:
   GITHUB_TOKEN:
     description: Your GitHub token for authentication.
-    required: true
+    required: false
+    default: ${{ github.token }}
 
   FIRST_ISSUE:
     description: Comment to be posted to on first time issues.


### PR DESCRIPTION
### Description

I have configured default token `${{ github.token }}` so that users doesn't need to specify the `${{ secrets.GITHUB_TOKEN }}` every time.

### Motivation and Context

Like in the `README.md`'s example, when we want to use this workflow, we need to at least specify the workflow run's token `${{ secrets.GITHUB_TOKEN }}` or any custom tokens.
But, on workflow run's token, we can use the default value and remove the `GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}`.

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to change)
- [x] **Enhancement** (changes that improvement of current feature or performance)
- [x] **Refactoring** (changes that neither fixes a bug nor adds a feature)
- [ ] **Test Case** (changes that add missing tests or correct existing tests)
- [ ] **Code style optimization** (changes that do not affect the meaning of the code)
- [ ] **Docs** (changes that only update documentation)
- [ ] **Chore** (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.